### PR TITLE
Fixed deprecation warnings in Rails3

### DIFF
--- a/lib/fixture_replacement/attribute_builder.rb
+++ b/lib/fixture_replacement/attribute_builder.rb
@@ -47,7 +47,7 @@ module FixtureReplacement
     end
 
     def instantiate(hash_to_merge = {}, instance = active_record_class.new)
-      returning instance do
+      instance.tap do
         instantiate_parent_fixture(instance)
         call_attribute_body(instance, hash_to_merge)
         add_given_keys(instance, hash_to_merge)

--- a/lib/fixture_replacement/class_methods.rb
+++ b/lib/fixture_replacement/class_methods.rb
@@ -17,7 +17,7 @@ module FixtureReplacement
     end
 
     def load_example_data
-      load "#{rails_root}/db/example_data.rb"
+      load "#{::Rails.root.to_s}/db/example_data.rb"
     rescue LoadError
       # no-op.  If the file is not found, don't panic
     end


### PR DESCRIPTION
I have fixed two of the deprecation warnings in Rails 3.

This probably will not work on older versions of rails or ruby 1.8.6
